### PR TITLE
Raise an error if we don't know how to login to this type of site

### DIFF
--- a/SEChatWrapper.py
+++ b/SEChatWrapper.py
@@ -48,6 +48,8 @@ class SEChatWrapper(object):
       self.br.loginSO()
     elif self.site == "MSO":
       self.br.loginMSO()
+    else:
+      raise ValueError("Unable to login to site: %r" % (self.site,))
 
     self.logged_in = True
     self.logger.info("Logged in.")


### PR DESCRIPTION
I didn't realize that the site code I was using was invalid, and that that was why the login was failing. It might make sense to add an error message in this case.
