### PR TITLE
Handles replacement of MSO with MSE

### DIFF
--- a/SEChatBrowser.py
+++ b/SEChatBrowser.py
@@ -52,17 +52,17 @@ class SEChatBrowser:
     self.chatroot = "http://chat.meta.stackoverflow.com"
     self.updateFkey()
 
-  def loginMSO(self):
-    fkey = self.getSoup("http://meta.stackoverflow.com/users/login?returnurl = %2f") \
+  def loginMSE(self):
+    fkey = self.getSoup("http://meta.stackexchange.com/users/login?returnurl = %2f") \
              .find('input', {"name": "fkey"})['value']
     data = {"fkey": fkey,
             "oauth_version": "",
             "oauth_server": "",
             "openid_identifier": "https://openid.stackexchange.com/"}
-    self.session.post("http://meta.stackoverflow.com/users/authenticate",
+    self.session.post("http://meta.stackexchange.com/users/authenticate",
                       data=data,
                       allow_redirects=True)
-    self.chatroot = "http://chat.meta.stackoverflow.com"
+    self.chatroot = "http://chat.meta.stackexchange.com"
     self.updateFkey()
   def loginSO(self):
     fkey = self.getSoup("http://stackoverflow.com/users/login?returnurl = %2f") \

--- a/SEChatWrapper.py
+++ b/SEChatWrapper.py
@@ -28,6 +28,9 @@ class SEChatWrapper(object):
   def __init__(self, site="SE"):
     self.logger = _getLogger()
     self.br = SEChatBrowser.SEChatBrowser()
+    if site == 'MSO':
+      self.logger.warn("'MSO' should no longer be used, use 'MSE' instead.")
+      site = 'MSE'
     self.site = site
     self._previous = None
     self.message_queue = Queue.Queue()
@@ -46,8 +49,6 @@ class SEChatWrapper(object):
       self.br.loginChatSE()
     elif self.site == "SO":
       self.br.loginSO()
-    elif self.site == "MSO":
-      self.br.loginMSO()
     elif self.site == "MSE":
       self.br.loginMSE()
     else:


### PR DESCRIPTION
Updates `loginMSO` to be `loginMSE`.

If the site is `MSO`, log a warning and treat it as `MSE`.

`./test.py` works again after this change.
