### PR TITLE
Improves test message prefixes outside of manishearth/ChatExchange Travis environment

### DIFF
--- a/test/test_live_messages.py
+++ b/test/test_live_messages.py
@@ -17,7 +17,7 @@ if (os.environ.get('TRAVIS_BUILD_ID') and
     os.environ.get('TRAVIS_REPO_SLUG')):
     TEST_MESSAGE_PREFIX = (
         "[ [ChatExchange@Travis](https://travis-ci.org/"
-        "{0.TRAVIS_REPO_SLUG}/builds/{0.TRAVIS_BUILD_ID}) ] "
+        "{0[TRAVIS_REPO_SLUG]}/builds/{0[TRAVIS_BUILD_ID]}) ] "
     ).format(os.environ)
 else:
     TEST_MESSAGE_PREFIX = (


### PR DESCRIPTION
It now links to the build in the current repo, even if that's not the manishearth/ChatExchange. (Using the right ID but the wrong repo name, as it previously could do when run from my repo, produced a buggy-looking Travis page.)

It also uses ChatExchange@localhost, linked to the git repo, when not being run on Travis. (I wasn't sure what label to use here. It was previously producing a 404 link.)
