### PR TITLE
Parameterizes test_se_message_echo over an editable list of TEST_ROOMs.

### DIFF
--- a/test/test_live_messages.py
+++ b/test/test_live_messages.py
@@ -13,15 +13,18 @@ import live_testing
 logger = logging.getLogger(__name__)
 
 
+TEST_ROOMS = [
+    ('SE', '11540'), # Charcoal HQ
+]
+
+
 if live_testing.enabled:
-    def test_se_message_echo():
+    @pytest.mark.parametrize('host_id,room_id', TEST_ROOMS)
+    def test_se_message_echo(host_id, room_id):
         """
         Tests that we are able to send a message, and recieve it back
         within a reasonable amount of time, on Stack Exchange chat.
         """
-
-        host_id = 'SE'
-        room_id = '11540' # Charcoal HQ
 
         wrapper = SEChatWrapper(host_id)
         wrapper.login(


### PR DESCRIPTION
This lets us easily modify the list of rooms that this test is run against, each with independent pass/fail results. Ideally, this could be used to test that everything is always working against all three hosts, but there isn't a suitable test account for that purpose.

On the main branch, this should only include Charcoal HQ for now, but I'll also be adding the SO sandbox on my test branch.
