### PR TITLE
Use a nicer test message. (closed because it's targeting master instead of test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,9 @@ test: install-dependencies
 install-dependencies:
 	rm -rf src/*.egg-info
 	pip install -e .
+
+clean:
+	rm -rf src/*.egg-info
+	find . -type f -name '*.pyc' -delete
+	find . -type d -name '__pycache__' -delete
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='ChatExchange',
-    version='0.0.0dev4',
+    version='0.0.0dev5',
     url='https://github.com/Manishearth/ChatExchange',
     packages=[
         'chatexchange'

--- a/test/test_live_messages.py
+++ b/test/test_live_messages.py
@@ -43,13 +43,17 @@ if live_testing.enabled:
             live_testing.username,
             live_testing.password)
 
-        test_message_code = uuid.uuid4().hex
-        test_message = "%s `%s`" % (TEST_MESSAGE_PREFIX, test_message_code)
+        test_message_nonce = uuid.uuid4().hex
+        test_message = (
+            "%s This is a test message [for ChatExchange]("
+            "https://github.com/Manishearth/ChatExchange \"This is a "
+            "ChatExchange test message with the nonce %s.\")."
+            % (TEST_MESSAGE_PREFIX, test_message_nonce))
 
         replied = [False]
 
         def on_message(message, wrapper):
-            if test_message_code in message['content']:
+            if test_message_nonce in message['content']:
                 replied[0] = True
                 logger.debug("Saw expected echoed test chat message!")
             else:


### PR DESCRIPTION
The uuid/nonce doesn't need to be visible to other users, so I put it in the `title` text of a link instead.

See [example local messages here](http://chat.stackexchange.com/transcript/message/15226511#15226511).

Also adds a `make clean`, and bumps the version number.
