### PR TITLE
Adds a User-Agent, and a test to ensure it's used.

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -14,8 +14,14 @@ except:
 
 
 class SEChatBrowser(object):
+    user_agent = ('ChatExchange/0.dev '
+                  '(+https://github.com/Manishearth/ChatExchange)')
+
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': self.user_agent
+        })
         self.rooms = {}
         self.sockets = {}
         self.polls = {}


### PR DESCRIPTION
There should probably be a default user-agent. This seemed to be a common pattern:

```
ChatExchange/0.dev (+https://github.com/Manishearth/ChatExchange)
```

It's specified as a class attribute on browser so any subclass can easily override it. It's not used for WebSocket connections.

[Successful Travis build here](https://travis-ci.org/jeremybanks/ChatExchange/builds/24064300)
