### PR TITLE
Added delete() method for Message

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -270,6 +270,9 @@ class Browser(object):
             'messages/%s' % (message_id,),
             {'text': text})
 
+    def delete_message(self, message_id):
+        return self.post_fkeyed('messages/%s/delete' % (message_id, ))
+
     def get_history(self, message_id):
         """
         Returns the data from the history page for message_id.

--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -194,7 +194,7 @@ class Client(object):
         if action_type == 'send':
             action_type, room_id, text = action
         else:
-            assert action_type == 'edit'
+            assert action_type == 'edit' or action_type == 'delete'
             action_type, message_id, text = action
 
         sent = False
@@ -209,9 +209,11 @@ class Client(object):
             try:
                 if action_type == 'send':
                     response = self._br.send_message(room_id, text)
-                else:
-                    assert action_type == 'edit'
+                elif action_type == 'edit':
                     response = self._br.edit_message(message_id, text)
+                else:
+                    assert action_type == 'delete'
+                    response = self._br.delete_message(message_id)
             except requests.HTTPError as ex:
                 if ex.response.status_code == 409:
                     # this could be a throttling message we know how to handle

--- a/chatexchange/messages.py
+++ b/chatexchange/messages.py
@@ -138,6 +138,11 @@ class Message(object):
         self._client._request_queue.put(('edit', self.id, text))
         self._logger.info("Queued edit %r for message_id #%r.", text, self.id)
         self._logger.info("Queue length: %d.", self._client._request_queue.qsize())
+        
+    def delete(self):
+        self._client._request_queue.put(('delete', self.id, ''))
+        self._logger.info("Queued deletion for message_id #%r.", self.id)
+        self._logger.info("Queue length: %d.", self._client._request_queue.qsize())
 
     def star(self, value=True):
         del self.starred_by_you  # don't use cached value


### PR DESCRIPTION
Added `delete()` method for the Message class, tested in the Sandbox: http://chat.stackexchange.com/transcript/message/17586112#17586112
