### PR TITLE
Sleep for much shorter time

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -85,7 +85,7 @@ class Browser(object):
         response.raise_for_status()
 
         # XXX: until throttling is implemented everywhere in Client, at least add some delay here.
-        time.sleep(0.75)
+        time.sleep(0.1)
 
         return response
 


### PR DESCRIPTION
Currently, on every request there is a 3/4 of a second delay. This delay
impacts startup time on a single server by ~3 or 4 seconds, which is fairly noticeable. Decreasing this delay provided a performance boost & no noticeable problems when testing.
