### PR TITLE
Add length_check parameter to send_message method

### DIFF
--- a/chatexchange/rooms.py
+++ b/chatexchange/rooms.py
@@ -46,13 +46,13 @@ class Room(object):
     def join(self):
         return self._client._join_room(self.id)
 
-    def send_message(self, text):
+    def send_message(self, text, length_check=True):
         """
         Sends a message (queued, to avoid getting throttled)
         @ivar text: The message to send
         @type text: L{str}
         """
-        if len(text) > 500:
+        if len(text) > 500 and length_check:
             self._logger.info("Could not send message because it was longer than 500 characters.")
             return
         if len(text) == 0:


### PR DESCRIPTION
This parameter should be used in case you don't want the length check. For
multiline messages, it's sometimes valid to have a message longer than 500
characters, but then CE wouldn't post it anyway. So I added this parameter,
which we need for SmokeDetector's new !!/errorlogs command.