### PR TITLE
Don't set room for event when room id isn't passed

### DIFF
--- a/chatexchange/events.py
+++ b/chatexchange/events.py
@@ -45,7 +45,10 @@ class Event(object):
             self.type_id = data['event_type']
 
         self.id = data['id']
-        self.room = client.get_room(data['room_id'], name=data['room_name'])
+        if 'room_id' in data:
+            self.room = client.get_room(data['room_id'], name=data['room_name'])
+        else:
+            self.room = None
         self.time_stamp = data['time_stamp']
 
         self._init_from_data()


### PR DESCRIPTION
Based on [Tim Stone's message](http://chat.stackexchange.com/transcript/message/20305029#20305029):

> That's an invalid assumption about room_id anyway isn't it? I don't think that's provided for at least event_type = 14 (global notifications)

Fixes #84.

r? @Manishearth