### PR TITLE
Fix #90.

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -411,7 +411,8 @@ class Browser(object):
         transcript_soup = self.get_soup(
             'transcript/message/%s' % (message_id,))
 
-        room_soup, = transcript_soup.select('.room-name a')
+        room_soups = transcript_soup.select('.room-name a')
+        room_soup = room_soups[-1]
         room_id = int(room_soup['href'].split('/')[2])
         room_name = room_soup.text
 


### PR DESCRIPTION
Fetching the room data in get_transcript_with_message failed when there
was a oneboxed room on the transcript. This commit fixes that.

r? @Manishearth