### PR TITLE
Add on_websocket_closed as notification

### DIFF
--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -55,9 +55,11 @@ class Client(object):
         self.host = host
         self.logged_in = False
         self._request_queue = Queue.Queue()
+        self.on_websocket_closed = None
 
         self._br = browser.Browser()
         self._br.host = host
+        self._br.on_websocket_closed = self.on_websocket_closed
         self._previous = None
         self._recently_gotten_objects = collections.deque(maxlen=self._max_recently_gotten_objects)
         self._requests_served = 0


### PR DESCRIPTION
When using ChatExchange, it's very useful to know when the chat web socket
is closed; if people can get notified about it, they can re-join the room
to fix everything, but before this commit, it was not possible to find out
when a web socket was closed (except using an except hook, but that's a
bit overkill for one kind of error like this).

r? @Manishearth