### PR TITLE
Re-raise exception if on_websocket_closed is None

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -639,9 +639,11 @@ class RoomSocketWatcher(object):
         while not self.killed:
             try:
                 a = self.ws.recv()
-            except websocket.WebSocketConnectionClosedException:
+            except websocket.WebSocketConnectionClosedException as e:
                 if self.on_websocket_closed is not None:
                     self.on_websocket_closed(self.room_id)
+                else:
+                    raise e
                 self.killed = True
                 break
 


### PR DESCRIPTION
If there's no method added to handle a closed websocket, ChatExchange would remain silent about it, but that should not happen.

r? @Manishearth