### PR TITLE
Problem with pip & requests on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A Python API for talking to Stack Exchange chat.
 ## Dependencies
 
  - BeautifulSoup (`sudo apt-get install python-beautifulsoup`)
- - Requests (`pip install requests`). Usually there by default. Please upgrade it with `pip install requests --upgrade`
+ - Requests (`pip install requests`). Usually there by default. Please upgrade it with `pip install requests --upgrade`  
+   *Note that Ubuntu comes with an old version of `pip` that is not compatible any more with the latest version of `requests`. It will be broken after you installed `requests`, except if you update it before (or afterwards) with `easy_install pip`.*
  - python-websockets for the experimental websocket listener (`pip install websocket-client`). This module is optional, without it `initSocket()` from SEChatBrowser will not work
 
 ## Shortcuts


### PR DESCRIPTION
There is a version incompatibility between the pip installed on Ubuntu/available in its official repositories and the latest requests module. As soon as requests is upgraded, pip will stop working. Therefore it is important to upgrade pip too.