### PR TITLE
Add methods to get pingable user IDs/names

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -601,6 +601,22 @@ class Browser(object):
             'tags': tags
         }
 
+    def get_pingable_user_ids_in_room(self, room_id):
+        url = "rooms/pingable/{0}".format(room_id)
+        resp_json = self.get(url).json()
+        user_ids = []
+        for user in resp_json:
+            user_ids.append(user[0])
+        return user_ids
+
+    def get_pingable_user_names_in_room(self, room_id):
+        url = "rooms/pingable/{0}".format(room_id)
+        resp_json = self.get(url).json()
+        user_names = []
+        for user in resp_json:
+            user_names.append(user[1])
+        return user_names
+
     def set_websocket_recovery(self, on_ws_closed):
         self.on_websocket_closed = on_ws_closed
         for s in self.sockets:

--- a/chatexchange/rooms.py
+++ b/chatexchange/rooms.py
@@ -101,6 +101,12 @@ class Room(object):
     def new_messages(self):
         return MessageIterator(self)
 
+    def get_pingable_user_ids(self):
+        return self._client._br.get_pingable_user_ids_in_room(self.id)
+
+    def get_pingable_user_names(self):
+        return self._client._br.get_pingable_user_names_in_room(self.id)
+
 
 class FilteredEventIterator(object):
     def __init__(self, room, types):


### PR DESCRIPTION
Room.get_pingable_user_ids: gets the pingable user IDs
Room.get_pingable_user_names: gets the pingable user names

The methods don't fetch actual User object, because for crowded rooms that
might send lots of web requests.

Important note: to use these methods, logging in on the Client is
required. You'll get an empty response if you don't.

r? @Manishearth