### PR TITLE
Get rid of BACKOFF_MULTIPLIER

### DIFF
--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -185,7 +185,6 @@ class Client(object):
             self._request_queue.task_done()
 
     # Appeasing the rate limiter gods is hard.
-    _BACKOFF_MULTIPLIER = 2
     _BACKOFF_ADDER = 5
 
     # When told to wait n seconds, wait n * BACKOFF_MULTIPLIER + BACKOFF_ADDER
@@ -241,8 +240,7 @@ class Client(object):
                         "Attempt %d: denied: throttled, must wait %.1f seconds",
                         attempt, wait)
                     # Wait more than that, though.
-                    wait *= self._BACKOFF_MULTIPLIER
-                    wait += self._BACKOFF_ADDER
+                    wait += 1
                 else:  # Something went wrong. I guess that happens.
                     wait = self._BACKOFF_ADDER
                     logging.error(


### PR DESCRIPTION
... and when getting rate-limited, add only 1 second to the waiting time.

I've tried this and my bot had no problems when posting 20 messages to
chat.

r? @Manishearth