### PR TITLE
Specify "html.parser" for BeautifulSoup

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -108,11 +108,11 @@ class Browser(object):
 
     def get_soup(self, url, data=None, headers=None, with_chat_root=True):
         response = self.get(url, data, headers, with_chat_root)
-        return BeautifulSoup(response.content)
+        return BeautifulSoup(response.content, "html.parser")
 
     def post_soup(self, url, data=None, headers=None, with_chat_root=True):
         response = self.post(url, data, headers, with_chat_root)
-        return BeautifulSoup(response.content)
+        return BeautifulSoup(response.content, "html.parser")
 
     def post_fkeyed(self, url, data=None, headers=None):
         if data is None:
@@ -193,7 +193,7 @@ class Browser(object):
             # no prompt for us to handle
             return prompt_response
 
-        prompt_soup = BeautifulSoup(prompt_response.content)
+        prompt_soup = BeautifulSoup(prompt_response.content, "html.parser")
 
         data = {
             'session': prompt_soup.find('input', {'name': 'session'})['value'],


### PR DESCRIPTION
To avoid this warning:

```
C:\Python27\lib\site-packages\bs4\__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")
```

r? @Manishearth