### PR TITLE
Fix the BS4 search for the script needed to count current user IDs

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -621,7 +621,7 @@ class Browser(object):
     def get_current_user_ids_in_room(self, room_id):
         url = "/rooms/{0}/".format(room_id)
         soup = self.get_soup(url)
-        script_tag = soup.find_all('script')[3]
+        script_tag = soup.body.script
         users_js = re.compile(r"(?s)CHAT\.RoomUsers\.initPresent\(\[.+\]\);").findall(script_tag.text)[0]
         user_data = [x.strip() for x in users_js.split('\n') if len(x.strip()) > 0][1:-1]
         user_ids = []
@@ -632,7 +632,7 @@ class Browser(object):
     def get_current_user_names_in_room(self, room_id):
         url = "/rooms/{0}/".format(room_id)
         soup = self.get_soup(url)
-        script_tag = soup.find_all('script')[3]
+        script_tag = soup.body.script
         users_js = re.compile(r"(?s)CHAT\.RoomUsers\.initPresent\(\[.+\]\);").findall(script_tag.text)[0]
         user_data = [x.strip() for x in users_js.split('\n') if len(x.strip()) > 0][1:-1]
         user_names = []


### PR DESCRIPTION
Stack Exchange has apparently added another `script` element to the
header of the chat page, so when `Browser.get_current_user_ids_in_room()`
searches for the fourth `script` element which contains the list of
users present, it find a `script` in the `head`, not the one it's supposed
to find in the body of the page. This commit fixes that by having it
search for the first `script` in the `body`, which should be more resilient
against future changes in the scripts used in the header. The same
fix is applied to `Browser.get_current_user_names_in_room()`.