### PR TITLE
Build Epydocs to GitLab Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ epydocs/
 .idea/
 .iml
 
+# Visual Studio Code Files
+.vscode/
+
 # Python VirtualEnvs for local testing
 VEnvs/
 /venv-*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+stages:
+  - test-python3-latest
+  - test-python2-latest
+
+test-python3-latest:
+  stage: test-python3-latest
+  image: python:3
+  script:
+  - pip install .
+  - python -m pytest
+
+test-python2-latest:
+  stage: test-python2-latest
+  image: python:2
+  script:
+  - pip install .
+  - python -m pytest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 stages:
   - test-python3-latest
   - test-python2-latest
+  - build
+  - deploy
 
 test-python3-latest:
   stage: test-python3-latest
@@ -15,3 +17,28 @@ test-python2-latest:
   script:
   - pip install .
   - python -m pytest
+
+build-epydocs:
+  stage: build
+  image: python:2
+  script:
+  - pip install .
+  - make epydocs
+  artifacts:
+    paths:
+    - epydocs/
+
+pages:
+  stage: deploy
+  dependencies:
+  - build-epydocs
+  only:
+  - master
+  - gl-pages
+  image: python:2
+  script:
+  - mkdir public/
+  - mv epydocs/ public/epydocs/
+  artifacts:
+    paths:
+    - public

--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -426,8 +426,9 @@ class Browser(object):
 
         messages_data = []
 
-        monologues_soups = transcript_soup.select(
-            '#transcript .monologue')
+        monologues_soups = transcript_soup.select('.monologue')
+
+        seen_target_message = False
 
         for monologue_soup in monologues_soups:
             user_link, = monologue_soup.select('.signature .username a')
@@ -436,7 +437,10 @@ class Browser(object):
             message_soups = monologue_soup.select('.message')
 
             for message_soup in message_soups:
-                message_id = int(message_soup['id'].split('-')[1])
+                this_message_id = int(message_soup['id'].split('-')[1])
+
+                if this_message_id == message_id:
+                    seen_target_message = True
 
                 edited = bool(message_soup.select('.edits'))
 
@@ -457,7 +461,7 @@ class Browser(object):
                     parent_message_id = None
 
                 message_data = {
-                    'id': message_id,
+                    'id': this_message_id,
                     'content': content,
                     'room_id': room_id,
                     'room_name': room_name,
@@ -476,6 +480,9 @@ class Browser(object):
                     message_data['edits'] = 0
 
                 messages_data.append(message_data)
+
+        if not seen_target_message:
+            logger.error("Did not see target message %s in scraped page." % (message_id))
 
         data = {
             'room_id': room_id,

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -19,7 +19,7 @@ def main(args):
     # Run `. setp.sh` to set the below testing environment variables
 
     host_id = 'stackexchange.com'
-    room_id = '14219'  # Charcoal Chatbot Sandbox
+    room_id = '1'  # Sandbox
 
     if 'ChatExchangeU' in os.environ:
         email = os.environ['ChatExchangeU']

--- a/examples/web_viewer.py
+++ b/examples/web_viewer.py
@@ -29,7 +29,7 @@ def main(port='8462'):
 
     logging.basicConfig(level=logging.INFO)
 
-    room_id = 14219  # Charcoal Chatbot Sandbox
+    room_id = 1  # Sandbox
 
     if 'ChatExchangeU' in os.environ:
         email = os.environ['ChatExchangeU']

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,14 +3,14 @@ from chatexchange import events, client
 
 def test_message_posted_event_initialization():
     event_type = 1
-    room_name = "Charcoal Chatbot Sandbox"
+    room_name = "Sandbox"
     content = 'hello <b>world</b>'
     intended_text_content = 'hello world'
     id = 28258802
     message_id = 15249005
-    room_id = 14219
+    room_id = 1
     time_stamp = 1398822427
-    user_id = 97938
+    user_id = 146115
     user_name = "bot"
 
     event_data = {
@@ -44,15 +44,15 @@ def test_message_posted_event_initialization():
 
 def test_message_edited_event_initialization():
     event_type = 2
-    room_name = "Charcoal Chatbot Sandbox"
+    room_name = "Sandbox"
     content = 'hello <b>world</b>'
     intended_text_content = 'hello world'
     id = 28258802
     message_id = 15249005
     message_edits = 2
-    room_id = 14219
+    room_id = 1
     time_stamp = 1398822427
-    user_id = 97938
+    user_id = 146115
     user_name = "bot"
 
     event_data = {
@@ -88,15 +88,15 @@ def test_message_edited_event_initialization():
 
 def test_message_starred_event_initialization():
     event_type = 6
-    room_name = "Charcoal Chatbot Sandbox"
+    room_name = "Sandbox"
     content = 'hello <b>world</b>'
     intended_text_content = 'hello world'
     id = 28258802
     message_id = 15249005
     message_stars = 3
-    room_id = 14219
+    room_id = 1
     time_stamp = 1398822427
-    user_id = 97938
+    user_id = 146115
     user_name = "bot"
 
     event_data = {

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,6 +4,8 @@ if sys.version_info[:2] <= (2, 6):
     logging.Logger.getChild = lambda self, suffix:\
         self.manager.getLogger('.'.join((self.name, suffix)) if self.root is not self else suffix)
 
+import pytest
+
 from chatexchange import Client
 
 from tests import live_testing
@@ -13,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 if live_testing.enabled:
+    @pytest.mark.timeout(240)
     def test_specific_messages():
         client = Client('stackexchange.com')
 
@@ -22,7 +25,7 @@ if live_testing.enabled:
         assert message1.text_content == '@JeremyBanks hello'
         assert message1.content_source == ":15358991 **hello**"
         assert message1.owner.id == 1251
-        assert message1.room.id == 14219
+        assert message1.room.id == 1
 
         message2 = message1.parent
 

--- a/tests/test_openid_login.py
+++ b/tests/test_openid_login.py
@@ -8,6 +8,7 @@ from tests import live_testing
 
 
 if live_testing.enabled:
+    @pytest.mark.timeout(240)
     def test_openid_login_recognizes_failure():
         """
         Tests that failed SE OpenID logins raise errors.

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -4,8 +4,10 @@ if sys.version_info[:2] <= (2, 6):
     logging.Logger.getChild = lambda self, suffix:\
         self.manager.getLogger('.'.join((self.name, suffix)) if self.root is not self else suffix)
 
+import pytest
+
 import chatexchange
-from chatexchange.events import MessageEdited
+from chatexchange.events import MessageEdited, MessageDeleted
 
 from tests import live_testing
 
@@ -14,30 +16,33 @@ logger = logging.getLogger(__name__)
 
 
 if live_testing.enabled:
+    @pytest.mark.timeout(240)
     def test_room_info():
         client = chatexchange.Client('stackexchange.com')
 
         a_feeds_user = client.get_user(-2)
-        bot_user = client.get_user(97938)
-        sandbox = client.get_room(14219)
+        bot_user = client.get_user(146115)
+        sandbox = client.get_room(1)
 
         assert bot_user in sandbox.owners
         assert a_feeds_user not in sandbox.owners
         assert sandbox.user_count >= 4
         assert sandbox.message_count >= 10
-        assert 'test' in sandbox.tags
+        assert 'sandbox' in sandbox.tags
 
         # we aren't checking these result, just that it doesn't blow up
         sandbox.description
         sandbox.text_description
-        sandbox.parent_site_name + sandbox.name
+        sandbox.parent_site_name
+        sandbox.name
 
+    @pytest.mark.timeout(240)
     def test_room_iterators():
         client = chatexchange.Client(
             'stackexchange.com', live_testing.email, live_testing.password)
 
         me = client.get_me()
-        sandbox = client.get_room(14219)
+        sandbox = client.get_room(1)
 
         my_message = None
 
@@ -60,4 +65,13 @@ if live_testing.enabled:
 
                 if edit.message is my_message:
                     assert my_message.content == "hello world"
+                    break
+
+        with sandbox.new_events(MessageDeleted) as deletions:
+            my_message.delete()
+
+            for deletion in deletions:
+                assert isinstance(deletion, MessageDeleted)
+
+                if deletion.message is my_message:
                     break

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,16 +1,19 @@
+import pytest
+
 import chatexchange
 
 from tests import live_testing
 
 
 if live_testing.enabled:
+    @pytest.mark.timeout(240)
     def test_user_info():
         client = chatexchange.Client('stackexchange.com')
 
         user = client.get_user(-2)
         assert user.id == -2
         assert not user.is_moderator
-        assert user.name == "Stack Exchange"
+        assert user.name == "Feeds"
         assert user.room_count >= 18
         assert user.message_count >= 129810
         assert user.reputation == -1


### PR DESCRIPTION
*depends on #139*

Builds our Epydocs for every commit on GitLab CI, and publishes to the project's GitLab Pages for every new commit on `master` (or `gl-pages`, intended for development).

As an example [here's the latest build output for my GitLab fork](http://banks.gitlab.io/ChatExchange/epydocs/class-tree.html).