### PR TITLE
Minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ script:
 branches:
   only:
     - master
+    - /^travis-ci(\-.+)?$/
 env:
   global:
     - secure: "S9c9S/OgKGa7mLz/Ys0aVwbyNtxBubUVWO0i3ew0sm0KwUBFiNNPtWTyCT21jGrjd1Zp0AvMlcSFhJ9auGAMAVIqPTqM1GkNGU5fPwx6Lo3KAGSqW+XN2cAFXljEyAQ2Bhn/ilWeUymC1EpkNRIDarCJZcNsctrs8P3H67gSFtc="
-    - secure: "av9hxTZp/Dhe9xAOq6WlhTNDoWjjczN3lFanG6h/3h4kW7DsxhfXMRA96z6MambbC6c9ARFiwsQ24NeCAfPQ1m6r9uZwNkusqnRDOwZQeVQcmopnoNNG4Kd/9oclIVgsAlSG6WfhkyQPUG2p7PkOvxFV4/YjDSViYDR3eoih3JA="
 notifications:
   email: false

--- a/chatexchange/events.py
+++ b/chatexchange/events.py
@@ -151,6 +151,7 @@ class MessageEdited(MessageEvent):
 @register_type
 class UserEntered(Event):
     type_id = 3
+
     def _init_from_data(self):
         self.user = self.client.get_user(
             self.data['user_id'], name=self.data['user_name'])
@@ -159,6 +160,7 @@ class UserEntered(Event):
 @register_type
 class UserLeft(Event):
     type_id = 4
+
     def _init_from_data(self):
         self.user = self.client.get_user(
             self.data['user_id'], name=self.data['user_name'])
@@ -171,6 +173,11 @@ class RoomNameChanged(Event):
 @register_type
 class MessageStarred(MessageEvent):
     type_id = 6
+
+
+@register_type
+class InternalEvent7(Event):
+    type_id = 7
 
 
 @register_type
@@ -194,8 +201,11 @@ class FileAdded(Event):
 
 
 @register_type
-class ModeratorFlag(Event):
+class MessageFlaggedForModerator(Event):
     type_id = 12
+
+# backwards-compatiblity alias
+ModeratorFlag = MessageFlaggedForModerator
 
 
 @register_type
@@ -209,8 +219,11 @@ class GlobalNotification(Event):
 
 
 @register_type
-class AccountLevelChanged(Event):
+class AccessLevelChanged(Event):
     type_id = 15
+
+# backwards-compatiblity alias
+AccountLevelChanged = AccessLevelChanged
 
 
 @register_type
@@ -234,8 +247,11 @@ class MessageMovedOut(MessageEvent):
 
 
 @register_type
-class MessagedMovedIn(MessageEvent):
+class MessageMovedIn(MessageEvent):
     type_id = 20
+
+# backwards-compatiblity alias
+MessagedMovedIn = MessageMovedIn
 
 
 @register_type
@@ -249,6 +265,36 @@ class FeedTicker(Event):
 
 
 @register_type
+class InternalEvent23(Event):
+    type_id = 23
+
+
+@register_type
+class InternalEvent24(Event):
+    type_id = 24
+
+
+@register_type
+class InternalEvent25(Event):
+    type_id = 25
+
+
+@register_type
+class InternalEvent26(Event):
+    type_id = 26
+
+
+@register_type
+class InternalEvent27(Event):
+    type_id = 27
+
+
+@register_type
+class InternalEvent28(Event):
+    type_id = 28
+
+
+@register_type
 class UserSuspended(Event):
     type_id = 29
 
@@ -256,3 +302,28 @@ class UserSuspended(Event):
 @register_type
 class UserMerged(Event):
     type_id = 30
+
+
+@register_type
+class InternalEvent31(Event):
+    type_id = 31
+
+
+@register_type
+class InternalEvent32(Event):
+    type_id = 32
+
+
+@register_type
+class InternalEvent33(Event):
+    type_id = 33
+
+
+@register_type
+class UserNameOrAvatarChanged(Event):
+    type_id = 34
+
+
+@register_type
+class InternalEvent35(Event):
+    type_id = 35

--- a/chatexchange/rooms.py
+++ b/chatexchange/rooms.py
@@ -105,6 +105,20 @@ class Room(object):
     def new_messages(self):
         return MessageIterator(self)
 
+    def get_pingable_users(self):
+        return [
+            self._client.get_user(user_id, name=name)
+            for (user_id, name, _1, _2)
+            in self._client._br.get_pingable_users_in_room(self.id)
+        ]
+
+    def get_current_users(self):
+        return [
+            self._client.get_user(user_id, name=name)
+            for (user_id, name)
+            in self._client._br.get_current_users_in_room(self.id)
+        ]
+
     def get_pingable_user_ids(self):
         return self._client._br.get_pingable_user_ids_in_room(self.id)
 

--- a/repl
+++ b/repl
@@ -1,0 +1,49 @@
+#!/usr/bin/env bpython -i
+import getpass
+import logging
+import os
+import sys
+
+import chatexchange
+
+
+logging.basicConfig(level=logging.WARNING)
+
+sys.stderr.write("chatexchange == %r\n" % (chatexchange))
+
+host = 'stackexchange.com'
+sys.stderr.write("host == %r\n" % (host))
+
+if 'ChatExchangeU' in os.environ:
+    email = os.environ['ChatExchangeU']
+    sys.stderr.write("# using email from $ChatExchangeU\n")
+else:
+    sys.stderr.write("# email: ")
+    sys.stderr.flush()
+    email = sys.stdin.readline()
+
+if email:
+    if 'ChatExchangeP' in os.environ:
+        password = os.environ['ChatExchangeP']
+        sys.stderr.write("# using password from $ChatExchangeP\n")
+    else:
+        sys.stderr.write("# password: ")
+        sys.stderr.flush()
+        password = getpass.getpass()
+else:
+    sys.stderr.write("# continuing without authentication")
+
+if email:
+    chat = chatexchange.Client(host, email, password)
+else:
+    chat = chatexchange.Client(host)
+sys.stderr.write("chat == %r\n" % (chat))
+
+sandbox = chat.get_room(1)
+sys.stderr.write("sandbox == %r\n" % (sandbox))
+
+me = chat.get_me()
+sys.stderr.write("me == %r\n" % (me))
+sys.stderr.write("me.name == %r\n" % (me.name))
+
+sys.stderr.write("\n")

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setuptools.setup(
         'pytest-timeout>=0.3',
         'pytest>=2.7.3',
         'py>=1.4.29',
+        'bpython>=0.16'
     ]
 )


### PR DESCRIPTION
- Add `Room.get_current_users()` and `.get_pingable_users()` returning lists of `User` objects. These are intended to replace the current `.get_pingable_user_ids()`, `.get_pingable_user_names()`, `.get_current_user_ids`, `.get_current_user_names()` methods. (We have the information for the `User` object in either case, but existing methods required multiple requests to the server if you wanted the IDs and the user names.)

- Minor changes to event types: renamed one to fix a typo, renamed two others to match the internal names (with backwards-compatibility aliases for all renames), and added placeholder `InternalEventN` events for all unknown-but-valid event IDs. (Some of these can occur for developer users, and without an event class to map on to they could cause a crash.) Added new `UserNameOrAvatarChanged` event type.

- Removed my obsolete credentials from the Travis configuration, and configured Travis to also run on branches named `travis-ci-*` (so that I can test branches on my Travis account without renaming them to `master`).

- Added BPython as a developer dependency and added a `./repl` script to launch it and configure a `chatexchange.Client`, because it's very satisfying to be able to easily jump in and experiment with the API like this:  
  <img width="907" alt="screen shot 2017-03-23 at 3 33 26 pm" src="https://cloud.githubusercontent.com/assets/18020/24266727/4528389c-0fde-11e7-90f3-54e5f1d46102.png">

---

You can see [my successful Travis build here](https://travis-ci.org/jeremyBanks/ChatExchange/builds/214389844):

[<img width="914" alt="screen shot 2017-03-23 at 3 58 42 pm" src="https://cloud.githubusercontent.com/assets/18020/24267720/a0a2cfc2-0fe1-11e7-989e-27eec28dbffa.png">](https://travis-ci.org/jeremyBanks/ChatExchange/builds/214389844)
