### PR TITLE
Adds `last_message` time from profile

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -569,8 +569,10 @@ class Browser(object):
 
         stats_elements = profile_soup.select('.user-valuecell')
         if len(stats_elements) >= 4:
+            last_message = _utils.parse_last_seen(stats_elements[1].text)
             last_seen = _utils.parse_last_seen(stats_elements[2].text)
         else:
+            last_message = -1
             last_seen = -1
 
         return {
@@ -579,7 +581,8 @@ class Browser(object):
             'message_count': message_count,
             'room_count': room_count,
             'reputation': reputation,
-            'last_seen': last_seen
+            'last_seen': last_seen,
+            'last_message': last_message
         }
 
     def get_room_info(self, room_id):

--- a/chatexchange/users.py
+++ b/chatexchange/users.py
@@ -19,6 +19,7 @@ class User(object):
     room_count = _utils.LazyFrom('scrape_profile')
     reputation = _utils.LazyFrom('scrape_profile')
     last_seen = _utils.LazyFrom('scrape_profile')
+    last_message = _utils.LazyFrom('scrape_profile')
 
     def scrape_profile(self):
         data = self._client._br.get_profile(self.id)
@@ -29,3 +30,4 @@ class User(object):
         self.room_count = data['room_count']
         self.reputation = data['reputation']
         self.last_seen = data['last_seen']
+        self.last_message = data['last_message']

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -30,4 +30,5 @@ if live_testing.enabled:
         assert user.id == -5
         assert not user.is_moderator
         assert user.last_seen == -1
+        assert user.last_message == -1
         assert user.reputation == -1


### PR DESCRIPTION
This change adds the `last_message` time to the `User` object. 

This time is found directly above the existing `last_seen` value.

---
![Last Message Last Seen](https://i.imgur.com/1XQVbv3.png)
---