### PR TITLE
Fix user id retrieval bug

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -230,7 +230,8 @@ class Browser(object):
     @staticmethod
     def user_id_and_name_from_link(link_soup):
         user_name = link_soup.text
-        user_id = int(link_soup['href'].split('/')[-2])
+        split_link = link_soup['href'].split('/')
+        user_id = int(split_link[split_link.index('users') + 1])
         return user_id, user_name
 
     def _update_chat_fkey_and_user(self):


### PR DESCRIPTION
When I originally submitted a PR back in November, I used -2 instead of 2 as the index for the user ID in the link because that would work whether or not the protocol were included in the URL. It seems that SE has changed something because now the username is no longer included, so this line is trying to convert 'users' to an integer. This fix doesn't try to hardcode the position of the ID, but instead gets it by finding the position of 'users' in the URL and then using the next one. There might be a better way of doing this, so I won't feel offended if you deny this PR, but I would like a similar solution and an upload to PyPI if possible because ChatExchange is currently unusable without a fix. (At least as far as I can tell.)