### PR TITLE
Cookie-based login

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -159,7 +159,18 @@ class Browser(object):
                 "check credentials provided for accuracy")
 
         self.host = host
-        return self.session.cookies.get('acct', None)
+        return self.session.cookies
+
+    def login_site_with_cookie(self, host, cookie_jar):
+        self.session.cookies.update(cookie_jar)
+
+        verify_soup = self.get_soup('https://%s/users/login' % (host,), with_chat_root=False)
+        profile_link = verify_soup.select('.my-profile')
+        logged_in = profile_link is not None and len(profile_link) > 0
+
+        if not logged_in:
+            raise LoginError("login with cookie could not be verified, "
+                             "try credential login instead")
 
     def _se_openid_login_with_fkey(self, fkey_url, post_url, data=()):
         """

--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -159,6 +159,7 @@ class Browser(object):
                 "check credentials provided for accuracy")
 
         self.host = host
+        return self.session.cookies.get('acct', None)
 
     def _se_openid_login_with_fkey(self, fkey_url, post_url, data=()):
         """

--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -135,13 +135,26 @@ class Client(object):
         assert not self.logged_in
         self.logger.info("Logging in.")
 
-        cookie = self._br.login_site(self.host, email, password)
+        cookies = self._br.login_site(self.host, email, password)
 
         self.logged_in = True
         self.logger.info("Logged in.")
         self._thread.start()
 
-        return cookie
+        return cookies
+
+    def login_with_cookie(self, cookie_jar):
+        """
+        Authenticates using a pre-fetched (by the client application) `acct` cookie.
+        """
+        assert not self.logged_in
+        self.logger.info("Logging in with acct cookie.")
+
+        self._br.login_site_with_cookie(self.host, cookie_jar)
+
+        self.logged_in = True
+        self.logger.info("Logged in (cookie).")
+        self._thread.start()
 
     def logout(self):
         """

--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -135,11 +135,13 @@ class Client(object):
         assert not self.logged_in
         self.logger.info("Logging in.")
 
-        self._br.login_site(self.host, email, password)
+        cookie = self._br.login_site(self.host, email, password)
 
         self.logged_in = True
         self.logger.info("Logged in.")
         self._thread.start()
+
+        return cookie
 
     def logout(self):
         """


### PR DESCRIPTION
Smokey has started to trigger captcha's on login. A lot. So... since the CE session gets lost across restarts, we need some way to restart it without logging in again - this is it.