### PR TITLE
Send aggressively fixup

### DIFF
--- a/chatexchange/markdown_detector.py
+++ b/chatexchange/markdown_detector.py
@@ -1,0 +1,26 @@
+"""
+A simple module to decide whether a chat message contains Markdown formatting
+"""
+
+import re
+
+
+mdre_code = re.compile(r'^ {4}')
+mdre_mono = re.compile(r'(?<!`)(`+)(?:[^`](?:.*?[^`])?)\1(?!`)')
+mdre_url  = re.compile(r'\b(?:https?|ftp)://[-~.%\w/]+')
+mdre_link = re.compile(r'\[(?:[^]\\]|\\.)+\]\({0}\)'.format(mdre_url.pattern))
+mdre_italics = re.compile(
+    r'(?<![*])[*](?:[^*]+|[*]{3,}|[*]{2}[^*]+[*]{2})+[*](?![*])')
+mdre_bold = re.compile(
+    r'(?<![*])[*][*](?:[^*]+|[*]{3,}[*][^*]+[*])+[*][*](?![*])')
+
+
+def markdown(text):
+    """
+    Return match object if text is Markdown-formatted, otherwise None.
+    @param text: The message to check for Markdown formatting.
+    @type text: L{str}
+    """
+    return mdre_code.match(text) or mdre_mono.search(text) or \
+        mdre_link.search(text) or mdre_url.search(text) or \
+            mdre_italics.search(text) or mdre_bold.search(text)

--- a/chatexchange/markdown_detector.py
+++ b/chatexchange/markdown_detector.py
@@ -6,6 +6,7 @@ import re
 
 
 mdre_code = re.compile(r'^ {4}')
+mdre_reply = re.compile(r'^:\d{8}')
 mdre_mono = re.compile(r'(?<!`)(`+)(?:[^`](?:.*?[^`])?)\1(?!`)')
 mdre_url  = re.compile(r'\b(?:https?|ftp)://[-~.%\w/]+')
 mdre_link = re.compile(r'\[(?:[^]\\]|\\.)+\]\({0}\)'.format(mdre_url.pattern))
@@ -21,6 +22,7 @@ def markdown(text):
     @param text: The message to check for Markdown formatting.
     @type text: L{str}
     """
-    return mdre_code.match(text) or mdre_mono.search(text) or \
-        mdre_link.search(text) or mdre_url.search(text) or \
-            mdre_italics.search(text) or mdre_bold.search(text)
+    return mdre_code.match(text) or mdre_reply.match(text) or \
+        mdre_mono.search(text) or mdre_link.search(text) or \
+            mdre_url.search(text) or mdre_italics.search(text) or \
+                mdre_bold.search(text)

--- a/chatexchange/rooms.py
+++ b/chatexchange/rooms.py
@@ -70,7 +70,7 @@ class Room(object):
         @ivar text: The message to send
         @type text: L{str}
         """
-        if len(text) > 500 and length_check:
+        if len(text) > 500 and length_check and '\n' not in text:
             self._logger.info("Could not send message because it was longer than 500 characters.")
             return
         if len(text) == 0:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,59 @@
+import sys
+import logging
+if sys.version_info[:2] <= (2, 6):
+    logging.Logger.getChild = lambda self, suffix:\
+        self.manager.getLogger('.'.join((self.name, suffix)) if self.root is not self else suffix)
+
+import pytest
+
+from chatexchange.markdown_detector import markdown
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_markdown():
+    assert markdown('no markdown here') is None
+    assert markdown('    code formatting') is not None
+    assert markdown('hello `code` here') is not None
+    assert markdown('bare url https://example.com/link gets linked') is not None
+    assert markdown('[hello](http://example.com/hello)') is not None
+    assert markdown('adjacent[hello](http://example.com/hello)text') is not None
+    assert markdown('adjacent.[hello](https://example.com/hello).x') is not None
+    assert markdown('[ftp](ftp://example.com/link) works too') is not None
+    assert markdown('text with *italics*') is not None
+    assert markdown('and **bold** too') is not None
+    assert markdown('*not italics') is None
+    assert markdown('**not bold either') is None
+    assert markdown('***not both neither too also as well') is None
+    assert markdown('****not bold or italic') is None
+    # Odd corner cases: many backticks
+    assert markdown('two ``backticks`` code') is not None
+    assert markdown('unpaired `single double`` fail') is None
+    assert markdown('unpaired `single triple``` fail') is None
+    # Weirdly, 'unpaired ``double triple```' gets rendered as
+    # 'unpaired <code>double triple</code>`'
+    #assert markdown('unpaired ``double triple``` fail') is not None
+    assert markdown('``````````````````18 ticks``````````````````') is not None
+    # Odd corner cases: broken links
+    assert markdown(
+        '[](http://example.com/link) gets linked inside parens') is not None
+    assert markdown('[no link]() is not linked') is None
+    assert markdown('[mailto is not linked](mailto:self@example.com)') is None
+    assert markdown('[sftp](sftp://example.com/link) is not linked') is None
+    assert markdown('[ftps](ftps://example.com/link) is not linked') is None
+    assert markdown(
+        '[https://example.com/no-link]() link in square brackets') is not None
+    assert markdown(
+        'empty anchor, link in parens [](https://example.com/)') is not None
+    # Odd corner cases: mixed bold and italics
+    assert markdown('this is ***bold italics***') is not None
+    assert markdown('this is **bold and *italics* too**') is not None
+    assert markdown(
+        'this is *italics and **bold** and **more** too*') is not None
+    # Odd corner cases: broken bold or italics
+    assert markdown('**unpaired neither*') is None
+    assert markdown('*unpaired nor**') is None
+    assert markdown('***unpaired** in the end') is None
+    # chat actually briefly formats as bold italics, then reverts
+    #assert markdown('****this is weird****') is None


### PR DESCRIPTION
This is a follup-up to PR #155 which cleans up a couple of problems which I discovered after the PR was merged.

The 500-character message limit is *possible* to override with `length_check` but without it, we still force multi-line messages to remain below the 500 limit. This seems to be (approximately?) where Stack Exchange hides part of the message behind a **(see full text)** link so staying below it by default seems to make sense.

This introduces a much more disciplined attempt at identifying messages which are Markdown (because you can't merge lines when they have rich formatting). I tried to resist using regex but I failed. The result is fairly succinct and reasonably accurate under the circumstances, but it's probably still possible to find corner cases where it does the wrong thing.

You can see this running (I hope!) in the Charcoal Test room starting from https://chat.stackexchange.com/transcript/message/49949548#49949548 (provided Metasmoke stays up, there have been some issues with that).