### PR TITLE
Updates from Charcoal

### DIFF
--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -665,7 +665,10 @@ class Browser(object):
         url = "/rooms/{0}/".format(room_id)
         soup = self.get_soup(url)
         script_tag = soup.body.script
-        users_js = re.compile(r"(?s)CHAT\.RoomUsers\.initPresent\(\[.+\]\);").findall(script_tag.text)[0]
+        script_text = script_tag.text;
+        if not script_text:
+            script_text = str(script_tag.string);
+        users_js = re.compile(r"(?s)CHAT\.RoomUsers\.initPresent\(\[.+\]\);").findall(script_text)[0]
         user_data = [x.strip() for x in users_js.split('\n') if len(x.strip()) > 0][1:-1]
         users = []
         for ud in user_data:

--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -163,6 +163,10 @@ class Browser(object):
 
     def login_site_with_cookie(self, host, cookie_jar):
         self.session.cookies.update(cookie_jar)
+        
+        # Can't log in to stackexchange.com any more because OpenID is gone; use meta instead.
+        if host == 'stackexchange.com':
+            host = 'meta.stackexchange.com'
 
         verify_soup = self.get_soup('https://%s/users/login' % (host,), with_chat_root=False)
         profile_link = verify_soup.select('.my-profile')

--- a/chatexchange/browser.py
+++ b/chatexchange/browser.py
@@ -715,7 +715,7 @@ class RoomSocketWatcher(object):
         self.ws = websocket.create_connection(
             wsurl, origin=self.browser.chat_root)
 
-        self.thread = threading.Thread(target=self._runner)
+        self.thread = threading.Thread(name="ChatExchange: RoomSocketWatcher for room #{}".format(self.room_id), target=self._runner)
         self.thread.setDaemon(True)
         self.thread.start()
 
@@ -747,7 +747,7 @@ class RoomPollingWatcher(object):
         self.killed = False
 
     def start(self):
-        self.thread = threading.Thread(target=self._runner)
+        self.thread = threading.Thread(name="ChatExchange: RoomPollingWatcher for room #{}".format(self.room_id), target=self._runner)
         self.thread.setDaemon(True)
         self.thread.start()
 

--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -93,7 +93,7 @@ class Client(object):
         self._previous = None
         self._recently_gotten_objects = collections.deque(maxlen=self._max_recently_gotten_objects)
         self._requests_served = 0
-        self._thread = threading.Thread(target=self._worker, name="message_sender")
+        self._thread = threading.Thread(target=self._worker, name="ChatExchange: message_sender for chat.{}".format(host))
         self._thread.setDaemon(True)
 
         self.aggressive_sender = send_aggressively


### PR DESCRIPTION
Adds some modifications that we've made to the Charcoal fork of ChatExchange. Thanks to @makyen for a number of these.

 * Don't bother trying OpenID to log in since SE doesn't support it any more
 * Improve sending efficiency by dropping extra waits since they don't appear to be necessary
 * Add names for each thread
 * BS4 update broke `get_current_users_in_room`: fix this