### PR TITLE
Recognize SE Chat response for 1 second wait

### DIFF
--- a/chatexchange/client.py
+++ b/chatexchange/client.py
@@ -17,7 +17,7 @@ import requests
 from . import browser, events, messages, rooms, users
 
 
-TOO_FAST_RE = r"You can perform this action again in (\d+) seconds"
+TOO_FAST_RE = r"You can perform this action again in (\d+) second"
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
When it's necessary to wait for only 1 second, the response from SE Chat is:
> You can perform this action again in 1 second.

which doesn't match the current `TOO_FAST_RE` regular expression, because that regex requires "seconds" to be plural. This PR just changes the regular expression to not care if the response is singular or plural by removing the final `s`.