### PR TITLE
Github Actions: Create lint+test.yml action

### DIFF
--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -1,0 +1,102 @@
+name: Run lint and tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version:
+          - '2.7'
+          # - '3.4'
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - 'pypy-2.7'
+          # - 'pypy-3.4'
+          # - 'pypy-3.5'
+          - 'pypy-3.6'
+          - 'pypy-3.7'
+          - 'pypy-3.8'
+          # - 'pypy-3.9'
+          # - 'pypy-3.10'
+        architecture:
+          - 'x86'
+          - 'x64'
+        # Some versions lack specific architecture on Linux on GH Actions
+        exclude:
+          - python-version: '2.7'
+            architecture: 'x86'
+          - python-version: 'pypy-2.7'
+            architecture: 'x86'
+          # - python-version: '3.4'
+          #   architecture: 'x86'
+          # - python-version: '3.4'
+          #   architecture: 'x64'
+          # - python-version: 'pypy-3.4'
+          #   architecture: 'x86'
+          # - python-version: 'pypy-3.4'
+          #   architecture: 'x64'
+          - python-version: '3.5'
+            architecture: 'x86'
+          # - python-version: 'pypy-3.5'
+          #   architecture: 'x86'
+          # - python-version: 'pypy-3.5'
+          #   architecture: 'x64'
+          - python-version: '3.6'
+            architecture: 'x86'
+          - python-version: 'pypy-3.6'
+            architecture: 'x86'
+          - python-version: '3.7'
+            architecture: 'x86'
+          - python-version: 'pypy-3.7'
+            architecture: 'x86'
+          - python-version: '3.8'
+            architecture: 'x86'
+          - python-version: 'pypy-3.8'
+            architecture: 'x86'
+          - python-version: '3.9'
+            architecture: 'x86'
+          # - python-version: 'pypy-3.9'
+          #   architecture: 'x86'
+          # - python-version: 'pypy-3.9'
+          #   architecture: 'x64'
+          - python-version: '3.10'
+            architecture: 'x86'
+          # - python-version: 'pypy-3.10'
+          #   architecture: 'x86'
+          # - python-version: 'pypy-3.10'
+          #   architecture: 'x64'
+
+    name: Python ${{ matrix.python-version }} ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python matrix
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -e .
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 chatexchange --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 chatexchange --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test
+        run:
+          python -m pytest


### PR DESCRIPTION
This implements CI testing on GithubActions as proposed in #162 

I'm using https://github.com/actions/setup-python and basically took their basic matrix example. (Earlier, back in August, I tried [a different tool based on `pyenv`](https://github.com/gabrielfalcao/pyenv-action), but that was a no go for several reasons.)

This does not yet cover all the tasks which were done in the old CI (epydoc etc) so I am not replacing that file just yet; but this closes #162 specifically, and lays the groundwork for replacing the remaining actions with Github Actions.

Unfortunately, Github Actions does not offer Python 3.4 on Ubuntu, so I left that out of the test matrix. There are a few other test cases which are commented out but in general I managed to get a test on either native Python or PyPy for all the other supported versions. (Perhaps it would be time to consider dropping 3.4 anyway? Though I believe it could be supported by adding an older Ubuntu version, or Windows, to the test matrix.)
For the list of supported versions, see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

This is a merge from my `master` branch because that was the only way to test exactly the integration I wanted to test. You can see results in https://github.com/tripleee/ChatExchange/actions (and also, unfortunately, several of my struggles to find what would work through trial and error :-)

For what it's worth, the `flake8` test runs with a very narrow set of conditions for hard failures, then runs again in report-only mode and shows quite a number of problems. This threw me off at first because I was left wondering why it didn't fail in spite of all those flake8 errors ...