### PR TITLE
setup.py: move dev dependencies to extras_require

### DIFF
--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install -e .
+          pip install -e .[dev]
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ A Python2 and Python3 cross-version API for talking to Stack Exchange chat.
    *Note that Ubuntu comes with an old version of `pip` that is not compatible any more with the latest version of `requests`. It will be broken after you installed `requests`, except if you update it before (or afterwards) with `easy_install pip` or `pip install --upgrade pip` (that one works only before).*
  - python-websockets for the experimental websocket listener (`pip install websocket-client`). This module is optional, without it `initSocket()` from SEChatBrowser will not work
 
+The package has a number of additional development requirements;
+install them with
+
+    pip install chatexchange[dev]
+
+or `.[dev]` if you are in the top directory of a local copy of the source.
+
 ## Shortcuts
 
 1. `make install-dependencies` will install the necessary Python package dependencies into your current environment (active virtualenv or system site packages)

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,17 @@ setuptools.setup(
     install_requires=[
         'beautifulsoup4>=4.3.2',
         'requests>=2.2.1',
-        'websocket-client>=0.13.0',
-        # only for dev:
-        'coverage>=4.5.0',
-        'epydoc>=3.0.1',
-        'httmock>=1.2.2',
-        'pytest-timeout>=0.3',
-        'pytest>=3.4.2',
-        'py>=1.5.0',
-        'bpython>=0.16'
-    ]
+        'websocket-client>=0.13.0'
+    ],
+    extras_require={
+        'dev': [
+            'coverage>=4.5.0',
+            'epydoc>=3.0.1',
+            'httmock>=1.2.2',
+            'pytest-timeout>=0.3',
+            'pytest>=3.4.2',
+            'py>=1.5.0',
+            'bpython>=0.16'
+        ]
+    }
 )


### PR DESCRIPTION
Installing the package should not pull in complex development requirements by default