### PR TITLE
.github/workflows/lint+test.yml: update for ubuntu-latest

### DIFF
--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '2.7'
+          # - '2.7'
           # - '3.4'
-          - '3.5'
-          - '3.6'
-          - '3.7'
+          # - '3.5'
+          # - '3.6'
+          # - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -28,61 +28,17 @@ jobs:
           - 'pypy-3.6'
           - 'pypy-3.7'
           - 'pypy-3.8'
-          # - 'pypy-3.9'
-          # - 'pypy-3.10'
+          - 'pypy-3.9'
+          - 'pypy-3.10'
         architecture:
-          - 'x86'
+          # - 'x86'
           - 'x64'
-        # Some versions lack specific architecture on Linux on GH Actions
-        exclude:
-          - python-version: '2.7'
-            architecture: 'x86'
-          - python-version: 'pypy-2.7'
-            architecture: 'x86'
-          # - python-version: '3.4'
-          #   architecture: 'x86'
-          # - python-version: '3.4'
-          #   architecture: 'x64'
-          # - python-version: 'pypy-3.4'
-          #   architecture: 'x86'
-          # - python-version: 'pypy-3.4'
-          #   architecture: 'x64'
-          - python-version: '3.5'
-            architecture: 'x86'
-          # - python-version: 'pypy-3.5'
-          #   architecture: 'x86'
-          # - python-version: 'pypy-3.5'
-          #   architecture: 'x64'
-          - python-version: '3.6'
-            architecture: 'x86'
-          - python-version: 'pypy-3.6'
-            architecture: 'x86'
-          - python-version: '3.7'
-            architecture: 'x86'
-          - python-version: 'pypy-3.7'
-            architecture: 'x86'
-          - python-version: '3.8'
-            architecture: 'x86'
-          - python-version: 'pypy-3.8'
-            architecture: 'x86'
-          - python-version: '3.9'
-            architecture: 'x86'
-          # - python-version: 'pypy-3.9'
-          #   architecture: 'x86'
-          # - python-version: 'pypy-3.9'
-          #   architecture: 'x64'
-          - python-version: '3.10'
-            architecture: 'x86'
-          # - python-version: 'pypy-3.10'
-          #   architecture: 'x86'
-          # - python-version: 'pypy-3.10'
-          #   architecture: 'x64'
 
     name: Python ${{ matrix.python-version }} ${{ matrix.architecture }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python matrix
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
Several of the Python platforms which used to work no longer exist for ubuntu-latest

Also, update actions to their latest versions (checkout@v3, setup-python@v4)