### PR TITLE
.github/workflows/matrixtest.yml: use LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -11,37 +11,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version:
-          # - '2.7'
-          # - '3.4'
-          # - '3.5'
-          # - '3.6'
-          # - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - 'pypy-2.7'
-          # - 'pypy-3.4'
-          # - 'pypy-3.5'
-          - 'pypy-3.6'
-          - 'pypy-3.7'
-          - 'pypy-3.8'
-          - 'pypy-3.9'
-          - 'pypy-3.10'
-        architecture:
-          # - 'x86'
-          - 'x64'
-
-    name: Python ${{ matrix.python-version }} ${{ matrix.architecture }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup python matrix
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/matrixtest.yml
+++ b/.github/workflows/matrixtest.yml
@@ -1,0 +1,47 @@
+name: Run lint and tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  matrix-test:
+    strategy:
+      matrix:
+        python-version:
+          - '2.7'
+          # - '3.4'
+          # - '3.5'
+          # - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          # - 'pypy-3.4'
+          # - 'pypy-3.5'
+          - 'pypy-3.6'
+          - 'pypy-3.7'
+          - 'pypy-3.8'
+          - 'pypy-3.9'
+          - 'pypy-3.10'
+          # - 'pypy-3.11'
+          # - 'pypy-3.12'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: LizardByte/setup-python-action@master
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+          pip install pytest
+      - name: Test
+        run:
+          python -m pytest


### PR DESCRIPTION
Reconstruct the test matrix but run it separately from the regular lint+test

This brings back 2.7 but Python 3 versions older than 3.7 are still untested

.github/workflows/lint+test.yml: scale down to only lint+test with Python 3.12