### PR TITLE
Fix typo in se-chat-interface.md

### DIFF
--- a/docs/se-chat-interface.md
+++ b/docs/se-chat-interface.md
@@ -21,7 +21,7 @@ fields:
 - `2` - message edited
 - `6` - message starred or unstarred
 
-All message events contain the the following fields based on the message
+All message events contain the following fields based on the message
 they refer to:
 
 - `message_id` - integer


### PR DESCRIPTION
`se-chat-interface.md` file contains following string:

> All message events contain the the following fields based on the message they refer to:

I remove a type (double `the`)

> All message events contain the following fields based on the message they refer to: